### PR TITLE
add an react method to access the charge counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,24 +42,28 @@ or
 ```javascript
 import RNFullBatteryStatus from 'react-native-full-battery-status';
 
-getHealthStatus()
-Returns: // COLD, GOOD, DEAD, OVER_VOLTAGE, OVER_HEAT
+async () => {
+	await getHealthStatus();
+	Returns: // COLD, GOOD, DEAD, OVER_VOLTAGE, OVER_HEAT
 
-getChargingStatus()
-Returns: // CHARGING, DISCHARGING, FULL, NOT_CHARGING, UNKNOWN
+	await getChargingStatus();
+	Returns: // CHARGING, DISCHARGING, FULL, NOT_CHARGING, UNKNOWN
 
-getTechnology()
-Returns: // WIRELESS, AC, USB, NONE
+	await getTechnology();
+	Returns: // WIRELESS, AC, USB, NONE
 
-getBatteryPercent()
-Returns: // eg => 43
+	await getBatteryPercent();
+	Returns: // eg => 43
 
-getTemperature()
-Returns: // eg => 30.5
+	await getTemperature();
+	Returns: // eg => 30.5
 
-getVoltage()
-Returns: // eg => 3851
+	await getVoltage();
+	Returns: // eg => 3851
 
+	await getChargeCounter();
+	Returns: // eg => 1201746 microampere-hours
+}
 
 ```
 

--- a/android/src/main/java/com/benvgroup/BatteryStatus.java
+++ b/android/src/main/java/com/benvgroup/BatteryStatus.java
@@ -19,7 +19,7 @@ public class BatteryStatus extends BroadcastReceiver {
   private float temperatureResult;
   private long capacity;
   private Context context;
-
+  private long chargeCounter;
   @Override
   public void onReceive(Context context, Intent intent) {
     this.context = context;
@@ -127,10 +127,21 @@ public class BatteryStatus extends BroadcastReceiver {
       voltage = intent.getIntExtra(BatteryManager.EXTRA_VOLTAGE, 0);
 
       capacity = getBatteryCapacity(this.context);
+
+      chargeCounter = getChargeCounter(this.context);
     }
 
   }
-
+  public long getPropertyChargeCounter(Context ctx) {
+    if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      BatteryManager manager = (BatteryManager) ctx.getSystemService(ctx.BATTERY_SERVICE);
+      return manager.getLongProperty(BatteryManager.BATTERY_PROPERTY_CHARGE_COUNTER);
+    }
+    return 0;
+  }
+  public long getChargeCounter(){
+    return getPropertyChargeCounter(context);
+  }
   public long getBatteryCapacity(Context ctx) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       BatteryManager mBatteryManager = (BatteryManager) ctx.getSystemService(Context.BATTERY_SERVICE);

--- a/android/src/main/java/com/benvgroup/RNFullBatteryStatusModule.java
+++ b/android/src/main/java/com/benvgroup/RNFullBatteryStatusModule.java
@@ -136,6 +136,15 @@ public class RNFullBatteryStatusModule extends ReactContextBaseJavaModule implem
       promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
     }
   }
+  @ReactMethod
+  public void getChargeCounter(final Promise promise){
+    try {
+        float type = (float) batteryStatusReceiver.getChargeCounter();
+        promise.resolve(type);
+      } catch (Exception ex) {
+        promise.reject("ERR_UNEXPECTED_EXCEPTION", ex);
+      }
+  }
 
   @Override
   public void onHostResume() {


### PR DESCRIPTION
This PR will expose a react method to access the BATTERY_PROPERTY_CHARGE_COUNTER from the android Battery Manager, and edit the docs to include it and specify that all methods are promises.